### PR TITLE
Removed unuseful redirect to password reset.

### DIFF
--- a/routes/web/adminarea.php
+++ b/routes/web/adminarea.php
@@ -23,9 +23,8 @@ Route::domain(domain())->group(function () {
              });
 
              // Password Reset Routes
-             Route::get('passwordreset')->name('passwordreset')->uses('RedirectionController@passwordreset');
              Route::name('passwordreset.')->prefix('passwordreset')->group(function () {
-                 Route::get('request')->name('request')->uses('PasswordResetController@request');
+                 Route::get('/{request?}')->name('request')->uses('PasswordResetController@request')->where('request', 'request');
                  Route::post('send')->name('send')->uses('PasswordResetController@send');
                  Route::get('reset')->name('reset')->uses('PasswordResetController@reset');
                  Route::post('process')->name('process')->uses('PasswordResetController@process');


### PR DESCRIPTION
The route removed redirects to the front area but not useful when we are in the admin area.
Changed to redirect to the "passwordreset" in the admin area. I made the "/request" in the URL optional so he can access the same page by "passwordreset" or "/passwordreset/request" both are the same.